### PR TITLE
don't display the menu when hidden

### DIFF
--- a/dist/menu/tooltip.js
+++ b/dist/menu/tooltip.js
@@ -120,7 +120,7 @@ var Tooltip = (function () {
     value: function close() {
       if (this.isOpen) {
         this.isOpen = false;
-        this.dom.style.opacity = this.pointer.style.opacity = 0;
+        this.dom.style.display = this.pointer.style.display = 'none';
       }
     }
   }]);

--- a/src/menu/tooltip.js
+++ b/src/menu/tooltip.js
@@ -99,7 +99,7 @@ export class Tooltip {
   close() {
     if (this.isOpen) {
       this.isOpen = false
-      this.dom.style.opacity = this.pointer.style.opacity = 0
+      this.dom.style.display = this.pointer.style.display = 'none'
     }
   }
 }


### PR DESCRIPTION
Current logic is to set opacity to 0, but this makes the menu still clickable and interferes with the user experience. 
New logic is to set the display to none, which works because the 'show' logic re-adds the dom elements to the page. 
